### PR TITLE
feat: add config option to enforce single  newline

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ pub struct Config {
     pub masterpath: Option<String>,
     pub masterkey: Option<String>,
     #[serde(default = "_default_true")]
+    pub forcenewline: bool,
+    #[serde(default = "_default_true")]
     pub verifycontent: bool,
     pub sources: Vec<Source>,
     pub layout: Vec<Template>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub struct Config {
     pub masterpath: Option<String>,
     pub masterkey: Option<String>,
     #[serde(default = "_default_true")]
-    pub forcenewline: bool,
+    pub adjustspacing: bool,
     #[serde(default = "_default_true")]
     pub verifycontent: bool,
     pub sources: Vec<Source>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,10 +65,14 @@ fn cmd_make(cfg_file: &Path, globals: &[String]) {
 
     for template in &cfg.layout {
         if template.source.is_none() {
-            let tmpl_rend = renderer.render(&template.name, ()).unwrap_or_else(|err| {
+            let mut tmpl_rend = renderer.render(&template.name, ()).unwrap_or_else(|err| {
                 bubble_error("Template error", err);
                 process::exit(1);
             });
+            if cfg.forcenewline {
+                tmpl_rend = tmpl_rend.trim().to_string();
+                tmpl_rend.push_str("\n\n");
+            }
             rendered.push_str(&tmpl_rend);
         } else {
             let src_name = &template.source.clone().unwrap();
@@ -94,17 +98,25 @@ fn cmd_make(cfg_file: &Path, globals: &[String]) {
 
             for (key, row) in &all_source_data[src_name] {
                 if items_set.contains(key) {
-                    let temp_rend =
+                    let mut tmpl_rend =
                         renderer
                             .render(&template.name, Some(row))
                             .unwrap_or_else(|err| {
                                 bubble_error("Template Error", err);
                                 process::exit(1);
                             });
-                    rendered.push_str(&temp_rend);
+
+                    if cfg.forcenewline {
+                        tmpl_rend = tmpl_rend.trim().to_string();
+                        tmpl_rend.push_str("\n\n");
+                    }
+                    rendered.push_str(&tmpl_rend);
                 }
             }
         }
+    }
+    if cfg.forcenewline {
+        rendered = rendered.trim().to_string();
     }
 
     if cfg.outputfile.is_none() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,8 +69,8 @@ fn cmd_make(cfg_file: &Path, globals: &[String]) {
                 bubble_error("Template error", err);
                 process::exit(1);
             });
-            if cfg.forcenewline {
-                tmpl_rend = tmpl_rend.trim().to_string();
+            if cfg.adjustspacing {
+                tmpl_rend = tmpl_rend.trim_end().to_string();
                 tmpl_rend.push_str("\n\n");
             }
             rendered.push_str(&tmpl_rend);
@@ -106,8 +106,8 @@ fn cmd_make(cfg_file: &Path, globals: &[String]) {
                                 process::exit(1);
                             });
 
-                    if cfg.forcenewline {
-                        tmpl_rend = tmpl_rend.trim().to_string();
+                    if cfg.adjustspacing {
+                        tmpl_rend = tmpl_rend.trim_end().to_string();
                         tmpl_rend.push_str("\n\n");
                     }
                     rendered.push_str(&tmpl_rend);
@@ -115,8 +115,8 @@ fn cmd_make(cfg_file: &Path, globals: &[String]) {
             }
         }
     }
-    if cfg.forcenewline {
-        rendered = rendered.trim().to_string();
+    if cfg.adjustspacing {
+        rendered = rendered.trim_end().to_string();
     }
 
     if cfg.outputfile.is_none() {

--- a/tests/testdata/test.yaml
+++ b/tests/testdata/test.yaml
@@ -1,8 +1,8 @@
-# outputfile: test.cnfg
+outputfile: test.cnfg
 
 templatepath: templates
 
-forcenewline: true
+adjustspacing: true
 
 verifycontent: true
 

--- a/tests/testdata/test.yaml
+++ b/tests/testdata/test.yaml
@@ -1,6 +1,8 @@
-outputfile: test.cnfg
+# outputfile: test.cnfg
 
 templatepath: templates
+
+forcenewline: true
 
 verifycontent: true
 


### PR DESCRIPTION
If true: Templates are written with exactly one newline in-between, and the last template is trimmed.
If false: Use default minjinja/jinja2 behavior of removing one trailing newline from the end of each template.