### PR TITLE
chore(deps): bump calamine from 1.19.1 to 1.21.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "calamine"
-version = "0.19.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6381d1037ee9b8a6c8eb97936add0331a1aabd148d5b6f35f1cda6e5dec44f40"
+checksum = "95f023f9ae2c2f017564b7eca85660c3c09477bb037f2fbfbaaba732b5642a32"
 dependencies = [
  "byteorder",
  "codepage",
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.25.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e21a144a0ffb5fad7b464babcdab934a325ad69b7c0373bcfef5cbd9799ca9"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
 dependencies = [
  "encoding_rs",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ lto = true      # 25 % reduction, result is 24% of original
 #panic = "abort"    # 7.5% reduction
 
 [dependencies]
-calamine = "0.19.1"
+calamine = "0.21.2"
 chrono = {version= "0.4.26", default-features=false, features=["clock"]}
 clap = { version = "4.1.8", features = ["derive", "cargo"] }
 colored = "2.0.0"

--- a/src/datasource.rs
+++ b/src/datasource.rs
@@ -150,6 +150,11 @@ impl DataSourceReader for ExcelSourceReader {
                                     CtxDataType::Error(CtxErrorType::GettingData)
                                 }
                             },
+                            DataType::Duration(_)
+                            | DataType::DateTimeIso(_)
+                            | DataType::DurationIso(_) => {
+                                panic!("Unhandled datatype for {cell})"); // Should never happen
+                            }
                         };
                         (header_str, value)
                     })


### PR DESCRIPTION
Three new datatypes:
Duration(f64), DateTimeIso(string), DurationIso(string)
Should be already converted as Float or String, so just panic if these are encountered.