### PR TITLE
test: fix broken tests in Windows

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -73,7 +73,7 @@ mod tests {
         let result = cmd_diff(file1.path(), file2);
         assert!(result.is_err());
         let error_message = result.unwrap_err().root_cause().to_string();
-        assert!(error_message.contains("No such file"));
+        assert!(error_message.contains("(os error 2)"));
         Ok(())
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,7 +153,7 @@ layout:
     fn config_fail_read_on_missing_config_file() {
         let config = Config::new(Path::new("nonexistent_file.yaml"));
         assert!(config.is_err());
-        assert!(config.unwrap_err().to_string().contains("No such file"));
+        assert!(config.unwrap_err().to_string().contains("os error 2"));
     }
 
     #[test]


### PR DESCRIPTION
Missing file gives different message in Mac and Win, use common part of error message in tests.