### PR TITLE
feat: add conditional includes/excludes for templates

### DIFF
--- a/src/commands/make.rs
+++ b/src/commands/make.rs
@@ -462,7 +462,7 @@ mod tests {
         let template = config::Template {
             name: "08_sources.tmpl".to_string(),
             source: Some("main".to_string()),
-            include: Some(vec![config::Include::List("one".to_string())]),
+            include: Some(vec![config::Include::Element("one".to_string())]),
             ..Default::default()
         };
         let all_source_data = get_all_source_data()?;

--- a/src/commands/make.rs
+++ b/src/commands/make.rs
@@ -462,7 +462,7 @@ mod tests {
         let template = config::Template {
             name: "08_sources.tmpl".to_string(),
             source: Some("main".to_string()),
-            include: Some(vec!["one".to_string()]),
+            include: Some(vec![config::Include::List("one".to_string())]),
             ..Default::default()
         };
         let all_source_data = get_all_source_data()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,8 +191,8 @@ impl Template {
                                 }
                             }
                         }
-                        if matched && matches!(elem.continue_, Some(false) | None) {
-                            return Ok(result);
+                        if matched && !elem.continue_.unwrap_or(false) {
+                            break;
                         }
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,7 +153,7 @@ pub struct Source {
 #[derive(Deserialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IncludeConditional {
-    items: Option<Vec<String>>,
+    items: Vec<String>,
     condition: String,
 }
 
@@ -186,12 +186,7 @@ impl Template {
                         let expr = env.compile_expression(elem.condition.as_str()).unwrap();
                         let eval = expr.eval(context! {}).unwrap();
                         if eval.is_true() {
-                            match &elem.items {
-                                Some(elems) => result.extend(elems.iter().cloned()),
-                                None => {
-                                    todo!("Can only filter source includes on global variables")
-                                }
-                            }
+                            result.extend(elem.items.clone());
                         }
                     }
                 }
@@ -212,12 +207,7 @@ impl Template {
                         let expr = env.compile_expression(elem.condition.as_str()).unwrap();
                         let eval = expr.eval(context! {}).unwrap();
                         if eval.is_true() {
-                            match &elem.items {
-                                Some(elems) => result.extend(elems.iter().cloned()),
-                                None => {
-                                    todo!("Can only filter source excludes on global variables")
-                                }
-                            }
+                            result.extend(elem.items.clone());
                         }
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,9 +125,10 @@ pub struct Source {
 #[derive(Deserialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IncludeConditional {
-    items: Option<Vec<String>>,
     #[serde(rename = "if")]
     condition: String,
+    #[serde(rename = "then")]
+    items: Option<Vec<String>>,
     #[serde(rename = "continue")]
     continue_: Option<bool>,
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -296,13 +296,15 @@ impl<'a> MiniJinja<'a> {
 
             if template.include.is_some() {
                 items_set = items_set
-                    .intersection(&template.include_set(&self.env))
+                    .intersection(
+                        &template.include_set(&self.env, source_data.get(src_name).unwrap()),
+                    )
                     .cloned()
                     .collect();
             }
 
             items_set = items_set
-                .difference(&template.exclude_set(&self.env))
+                .difference(&template.exclude_set(&self.env, source_data.get(src_name).unwrap()))
                 .cloned()
                 .collect();
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,6 +1,7 @@
 use crate::config;
 use crate::config::Counter as CounterConfig;
 use crate::datasource::DataSourceRows;
+use anyhow::Context;
 use chrono::Local;
 use minijinja::value::{from_args, Kwargs, Rest, Value, ValueKind};
 use minijinja::{Environment, Error, ErrorKind};
@@ -295,12 +296,15 @@ impl<'a> MiniJinja<'a> {
             let mut items_set: HashSet<String> = keys.iter().cloned().collect();
 
             if template.include.is_some() {
-                items_set = items_set
-                    .intersection(
-                        &template.include_set(&self.env, source_data.get(src_name).unwrap()),
+                let include_set = template
+                    .include_set(
+                        &self.env,
+                        source_data.get(src_name).expect(
+                            "render_template: unable to fetch source. This should not be possible!",
+                        ),
                     )
-                    .cloned()
-                    .collect();
+                    .with_context(|| format!("template {:?}", &template.name))?;
+                items_set = items_set.intersection(&include_set).cloned().collect();
             }
 
             items_set = items_set

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -297,18 +297,29 @@ impl<'a> MiniJinja<'a> {
 
             if template.include.is_some() {
                 let include_set = template
-                    .include_set(
+                    .include_exclude_set(
                         &self.env,
                         source_data.get(src_name).expect(
                             "render_template: unable to fetch source. This should not be possible!",
                         ),
+                        config::IncludeExclude::Include,
                     )
                     .with_context(|| format!("template {:?}", &template.name))?;
                 items_set = items_set.intersection(&include_set).cloned().collect();
             }
 
             items_set = items_set
-                .difference(&template.exclude_set(&self.env, source_data.get(src_name).unwrap()))
+                .difference(
+                    &template
+                        .include_exclude_set(
+                            &self.env,
+                            source_data.get(src_name).expect(
+                                "render_template: unable to fetch source. This should not be possible!",
+                            ),
+                            config::IncludeExclude::Exclude,
+                        )
+                        .with_context(|| format!("template {:?}", &template.name))?,
+                )
                 .cloned()
                 .collect();
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -296,7 +296,7 @@ impl<'a> MiniJinja<'a> {
 
             if template.include.is_some() {
                 items_set = items_set
-                    .intersection(&template.include_set())
+                    .intersection(&template.include_set(&self.env))
                     .cloned()
                     .collect();
             }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -302,7 +302,7 @@ impl<'a> MiniJinja<'a> {
             }
 
             items_set = items_set
-                .difference(&template.exclude_set())
+                .difference(&template.exclude_set(&self.env))
                 .cloned()
                 .collect();
 


### PR DESCRIPTION
Status:
- [x] Specify rows to include/exclude with conditions based on global variables
- [x] Filter individual rows based on condition for row (`items` must be made optional and we must iterate over all rows in the relevant source)
- [ ] ~Specify default items to include if no conditions match (is this needed? Can be handled by specifying condition = true)~